### PR TITLE
Issue 54 Protect internal commands from stubbing

### DIFF
--- a/shunit2
+++ b/shunit2
@@ -15,8 +15,8 @@
 # Disable ShellCheck checks that aren't fully portable (POSIX != portable).
 # shellcheck disable=SC2006
 
-# Return if shUnit2 already loaded.
-[ -n "${SHUNIT_VERSION:-}" ] && exit 0
+# Return if shunit2 already loaded.
+\[ -n "${SHUNIT_VERSION:-}" ] && exit 0
 SHUNIT_VERSION='2.1.7pre'
 
 # Return values that scripts can use.
@@ -49,12 +49,12 @@ SHUNIT_STRICT=${SHUNIT_STRICT:-${SHUNIT_TRUE}}
 SHUNIT_COLOR=${SHUNIT_COLOR:-auto}
 
 # Specific shell checks.
-if [ -n "${ZSH_VERSION:-}" ]; then
+if \[ -n "${ZSH_VERSION:-}" ]; then
   setopt |grep "^shwordsplit$" >/dev/null
-  if [ $? -ne ${SHUNIT_TRUE} ]; then
+  if \[ $? -ne ${SHUNIT_TRUE} ]; then
     _shunit_fatal 'zsh shwordsplit option is required for proper operation'
   fi
-  if [ -z "${SHUNIT_PARENT:-}" ]; then
+  if \[ -z "${SHUNIT_PARENT:-}" ]; then
     _shunit_fatal "zsh does not pass \$0 through properly. please declare \
 \"SHUNIT_PARENT=\$0\" before calling shUnit2"
   fi
@@ -121,10 +121,10 @@ __shunit_assertsFailed=0
 __shunit_assertsSkipped=0
 
 #
-# Macros
+# Macros.
 #
 
-_SHUNIT_LINENO_='eval __shunit_lineno=""; if [ "${1:-}" = "--lineno" ]; then [ -n "$2" ] && __shunit_lineno="[$2] "; shift 2; fi'
+_SHUNIT_LINENO_='eval __shunit_lineno=""; if \[ "${1:-}" = "--lineno" ]; then \[ -n "$2" ] && __shunit_lineno="[$2] "; shift 2; fi'
 
 #-----------------------------------------------------------------------------
 # Assertion functions.
@@ -140,7 +140,7 @@ _SHUNIT_LINENO_='eval __shunit_lineno=""; if [ "${1:-}" = "--lineno" ]; then [ -
 #   integer: success (TRUE/FALSE/ERROR constant)
 assertEquals() {
   ${_SHUNIT_LINENO_}
-  if [ $# -lt 2 -o $# -gt 3 ]; then
+  if \[ $# -lt 2 -o $# -gt 3 ]; then
     _shunit_error "assertEquals() requires two or three arguments; $# given"
     _shunit_error "1: ${1:+$1} 2: ${2:+$2} 3: ${3:+$3}${4:+ 4: $4}"
     return ${SHUNIT_ERROR}
@@ -148,7 +148,7 @@ assertEquals() {
   _shunit_shouldSkip && return ${SHUNIT_TRUE}
 
   shunit_message_=${__shunit_lineno}
-  if [ $# -eq 3 ]; then
+  if \[ $# -eq 3 ]; then
     shunit_message_="${shunit_message_}$1"
     shift
   fi
@@ -156,7 +156,7 @@ assertEquals() {
   shunit_actual_=$2
 
   shunit_return=${SHUNIT_TRUE}
-  if [ "${shunit_expected_}" = "${shunit_actual_}" ]; then
+  if \[ "${shunit_expected_}" = "${shunit_actual_}" ]; then
     _shunit_assertPass
   else
     failNotEquals "${shunit_message_}" "${shunit_expected_}" "${shunit_actual_}"
@@ -178,14 +178,14 @@ _ASSERT_EQUALS_='eval assertEquals --lineno "${LINENO:-}"'
 #   integer: success (TRUE/FALSE/ERROR constant)
 assertNotEquals() {
   ${_SHUNIT_LINENO_}
-  if [ $# -lt 2 -o $# -gt 3 ]; then
+  if \[ $# -lt 2 -o $# -gt 3 ]; then
     _shunit_error "assertNotEquals() requires two or three arguments; $# given"
     return ${SHUNIT_ERROR}
   fi
   _shunit_shouldSkip && return ${SHUNIT_TRUE}
 
   shunit_message_=${__shunit_lineno}
-  if [ $# -eq 3 ]; then
+  if \[ $# -eq 3 ]; then
     shunit_message_="${shunit_message_}$1"
     shift
   fi
@@ -193,7 +193,7 @@ assertNotEquals() {
   shunit_actual_=$2
 
   shunit_return=${SHUNIT_TRUE}
-  if [ "${shunit_expected_}" != "${shunit_actual_}" ]; then
+  if \[ "${shunit_expected_}" != "${shunit_actual_}" ]; then
     _shunit_assertPass
   else
     failSame "${shunit_message_}" "$@"
@@ -214,14 +214,14 @@ _ASSERT_NOT_EQUALS_='eval assertNotEquals --lineno "${LINENO:-}"'
 #   integer: success (TRUE/FALSE/ERROR constant)
 assertNull() {
   ${_SHUNIT_LINENO_}
-  if [ $# -lt 1 -o $# -gt 2 ]; then
+  if \[ $# -lt 1 -o $# -gt 2 ]; then
     _shunit_error "assertNull() requires one or two arguments; $# given"
     return ${SHUNIT_ERROR}
   fi
   _shunit_shouldSkip && return ${SHUNIT_TRUE}
 
   shunit_message_=${__shunit_lineno}
-  if [ $# -eq 2 ]; then
+  if \[ $# -eq 2 ]; then
     shunit_message_="${shunit_message_}$1"
     shift
   fi
@@ -243,14 +243,14 @@ _ASSERT_NULL_='eval assertNull --lineno "${LINENO:-}"'
 assertNotNull()
 {
   ${_SHUNIT_LINENO_}
-  if [ $# -gt 2 ]; then  # allowing 0 arguments as $1 might actually be null
+  if \[ $# -gt 2 ]; then  # allowing 0 arguments as $1 might actually be null
     _shunit_error "assertNotNull() requires one or two arguments; $# given"
     return ${SHUNIT_ERROR}
   fi
   _shunit_shouldSkip && return ${SHUNIT_TRUE}
 
   shunit_message_=${__shunit_lineno}
-  if [ $# -eq 2 ]; then
+  if \[ $# -eq 2 ]; then
     shunit_message_="${shunit_message_}$1"
     shift
   fi
@@ -274,14 +274,14 @@ _ASSERT_NOT_NULL_='eval assertNotNull --lineno "${LINENO:-}"'
 #   integer: success (TRUE/FALSE/ERROR constant)
 assertSame() {
   ${_SHUNIT_LINENO_}
-  if [ $# -lt 2 -o $# -gt 3 ]; then
+  if \[ $# -lt 2 -o $# -gt 3 ]; then
     _shunit_error "assertSame() requires two or three arguments; $# given"
     return ${SHUNIT_ERROR}
   fi
   _shunit_shouldSkip && return ${SHUNIT_TRUE}
 
   shunit_message_=${__shunit_lineno}
-  if [ $# -eq 3 ]; then
+  if \[ $# -eq 3 ]; then
     shunit_message_="${shunit_message_}$1"
     shift
   fi
@@ -303,14 +303,14 @@ _ASSERT_SAME_='eval assertSame --lineno "${LINENO:-}"'
 #   integer: success (TRUE/FALSE/ERROR constant)
 assertNotSame() {
   ${_SHUNIT_LINENO_}
-  if [ $# -lt 2 -o $# -gt 3 ]; then
+  if \[ $# -lt 2 -o $# -gt 3 ]; then
     _shunit_error "assertNotSame() requires two or three arguments; $# given"
     return ${SHUNIT_ERROR}
   fi
   _shunit_shouldSkip && return ${SHUNIT_TRUE}
 
   shunit_message_=${__shunit_lineno}
-  if [ $# -eq 3 ]; then
+  if \[ $# -eq 3 ]; then
     shunit_message_="${shunit_message_:-}$1"
     shift
   fi
@@ -345,14 +345,14 @@ _ASSERT_NOT_SAME_='eval assertNotSame --lineno "${LINENO:-}"'
 #   integer: success (TRUE/FALSE/ERROR constant)
 assertTrue() {
   ${_SHUNIT_LINENO_}
-  if [ $# -lt 1 -o $# -gt 2 ]; then
+  if \[ $# -lt 1 -o $# -gt 2 ]; then
     _shunit_error "assertTrue() takes one or two arguments; $# given"
     return ${SHUNIT_ERROR}
   fi
   _shunit_shouldSkip && return ${SHUNIT_TRUE}
 
   shunit_message_=${__shunit_lineno}
-  if [ $# -eq 2 ]; then
+  if \[ $# -eq 2 ]; then
     shunit_message_="${shunit_message_}$1"
     shift
   fi
@@ -361,21 +361,21 @@ assertTrue() {
   # See if condition is an integer, i.e. a return value.
   shunit_match_=`expr "${shunit_condition_}" : '\([0-9]*\)'`
   shunit_return=${SHUNIT_TRUE}
-  if [ -z "${shunit_condition_}" ]; then
+  if \[ -z "${shunit_condition_}" ]; then
     # Null condition.
     shunit_return=${SHUNIT_FALSE}
-  elif [ -n "${shunit_match_}" -a "${shunit_condition_}" = "${shunit_match_}" ]
+  elif \[ -n "${shunit_match_}" -a "${shunit_condition_}" = "${shunit_match_}" ]
   then
     # Possible return value. Treating 0 as true, and non-zero as false.
-    [ ${shunit_condition_} -ne 0 ] && shunit_return=${SHUNIT_FALSE}
+    \[ ${shunit_condition_} -ne 0 ] && shunit_return=${SHUNIT_FALSE}
   else
     # Hopefully... a condition.
     ( eval ${shunit_condition_} ) >/dev/null 2>&1
-    [ $? -ne 0 ] && shunit_return=${SHUNIT_FALSE}
+    \[ $? -ne 0 ] && shunit_return=${SHUNIT_FALSE}
   fi
 
   # Record the test.
-  if [ ${shunit_return} -eq ${SHUNIT_TRUE} ]; then
+  if \[ ${shunit_return} -eq ${SHUNIT_TRUE} ]; then
     _shunit_assertPass
   else
     _shunit_assertFail "${shunit_message_}"
@@ -409,14 +409,14 @@ _ASSERT_TRUE_='eval assertTrue --lineno "${LINENO:-}"'
 #   integer: success (TRUE/FALSE/ERROR constant)
 assertFalse() {
   ${_SHUNIT_LINENO_}
-  if [ $# -lt 1 -o $# -gt 2 ]; then
+  if \[ $# -lt 1 -o $# -gt 2 ]; then
     _shunit_error "assertFalse() quires one or two arguments; $# given"
     return ${SHUNIT_ERROR}
   fi
   _shunit_shouldSkip && return ${SHUNIT_TRUE}
 
   shunit_message_=${__shunit_lineno}
-  if [ $# -eq 2 ]; then
+  if \[ $# -eq 2 ]; then
     shunit_message_="${shunit_message_}$1"
     shift
   fi
@@ -425,21 +425,21 @@ assertFalse() {
   # See if condition is an integer, i.e. a return value.
   shunit_match_=`expr "${shunit_condition_}" : '\([0-9]*\)'`
   shunit_return=${SHUNIT_TRUE}
-  if [ -z "${shunit_condition_}" ]; then
+  if \[ -z "${shunit_condition_}" ]; then
     # Null condition.
     shunit_return=${SHUNIT_FALSE}
-  elif [ -n "${shunit_match_}" -a "${shunit_condition_}" = "${shunit_match_}" ]
+  elif \[ -n "${shunit_match_}" -a "${shunit_condition_}" = "${shunit_match_}" ]
   then
     # Possible return value. Treating 0 as true, and non-zero as false.
-    [ ${shunit_condition_} -eq 0 ] && shunit_return=${SHUNIT_FALSE}
+    \[ ${shunit_condition_} -eq 0 ] && shunit_return=${SHUNIT_FALSE}
   else
     # Hopefully... a condition.
     ( eval ${shunit_condition_} ) >/dev/null 2>&1
-    [ $? -eq 0 ] && shunit_return=${SHUNIT_FALSE}
+    \[ $? -eq 0 ] && shunit_return=${SHUNIT_FALSE}
   fi
 
   # Record the test.
-  if [ ${shunit_return} -eq ${SHUNIT_TRUE} ]; then
+  if \[ ${shunit_return} -eq ${SHUNIT_TRUE} ]; then
     _shunit_assertPass
   else
     _shunit_assertFail "${shunit_message_}"
@@ -462,14 +462,14 @@ _ASSERT_FALSE_='eval assertFalse --lineno "${LINENO:-}"'
 #   integer: success (TRUE/FALSE/ERROR constant)
 fail() {
   ${_SHUNIT_LINENO_}
-  if [ $# -gt 1 ]; then
+  if \[ $# -gt 1 ]; then
     _shunit_error "fail() requires zero or one arguments; $# given"
     return ${SHUNIT_ERROR}
   fi
   _shunit_shouldSkip && return ${SHUNIT_TRUE}
 
   shunit_message_=${__shunit_lineno}
-  if [ $# -eq 1 ]; then
+  if \[ $# -eq 1 ]; then
     shunit_message_="${shunit_message_}$1"
     shift
   fi
@@ -491,14 +491,14 @@ _FAIL_='eval fail --lineno "${LINENO:-}"'
 #   integer: success (TRUE/FALSE/ERROR constant)
 failNotEquals() {
   ${_SHUNIT_LINENO_}
-  if [ $# -lt 2 -o $# -gt 3 ]; then
+  if \[ $# -lt 2 -o $# -gt 3 ]; then
     _shunit_error "failNotEquals() requires one or two arguments; $# given"
     return ${SHUNIT_ERROR}
   fi
   _shunit_shouldSkip && return ${SHUNIT_TRUE}
 
   shunit_message_=${__shunit_lineno}
-  if [ $# -eq 3 ]; then
+  if \[ $# -eq 3 ]; then
     shunit_message_="${shunit_message_}$1"
     shift
   fi
@@ -523,14 +523,14 @@ _FAIL_NOT_EQUALS_='eval failNotEquals --lineno "${LINENO:-}"'
 failSame()
 {
   ${_SHUNIT_LINENO_}
-  if [ $# -lt 2 -o $# -gt 3 ]; then
+  if \[ $# -lt 2 -o $# -gt 3 ]; then
     _shunit_error "failSame() requires two or three arguments; $# given"
     return ${SHUNIT_ERROR}
   fi
   _shunit_shouldSkip && return ${SHUNIT_TRUE}
 
   shunit_message_=${__shunit_lineno}
-  if [ $# -eq 3 ]; then
+  if \[ $# -eq 3 ]; then
     shunit_message_="${shunit_message_}$1"
     shift
   fi
@@ -554,14 +554,14 @@ _FAIL_SAME_='eval failSame --lineno "${LINENO:-}"'
 #   integer: success (TRUE/FALSE/ERROR constant)
 failNotSame() {
   ${_SHUNIT_LINENO_}
-  if [ $# -lt 2 -o $# -gt 3 ]; then
+  if \[ $# -lt 2 -o $# -gt 3 ]; then
     _shunit_error "failNotEquals() requires one or two arguments; $# given"
     return ${SHUNIT_ERROR}
   fi
   _shunit_shouldSkip && return ${SHUNIT_TRUE}
 
   shunit_message_=${__shunit_lineno}
-  if [ $# -eq 3 ]; then
+  if \[ $# -eq 3 ]; then
     shunit_message_="${shunit_message_}$1"
     shift
   fi
@@ -709,11 +709,11 @@ _shunit_mktempDir() {
   ( exec mktemp -dqt shunit.XXXXXX 2>/dev/null ) && return
 
   # The standard `mktemp` didn't work. Use our own.
-  if [ -r '/dev/urandom' -a -x '/usr/bin/od' ]; then
+  if \[ -r '/dev/urandom' -a -x '/usr/bin/od' ]; then
     _shunit_random_=`/usr/bin/od -vAn -N4 -tx4 </dev/urandom \
         |sed 's/^[^0-9a-f]*//'`
-  elif [ -n "${RANDOM:-}" ]; then
-    # `$RANDOM` works.
+  elif \[ -n "${RANDOM:-}" ]; then
+    # $RANDOM works
     _shunit_random_=${RANDOM}${RANDOM}${RANDOM}$$
   else
     # `$RANDOM` doesn't work.
@@ -722,7 +722,7 @@ _shunit_mktempDir() {
   fi
 
   _shunit_tmpDir_="${TMPDIR:-/tmp}/shunit.${_shunit_random_}"
-  ( umask 077 && mkdir "${_shunit_tmpDir_}" ) || \
+  ( umask 077 && \mkdir "${_shunit_tmpDir_}" ) || \
       _shunit_fatal 'could not create temporary directory! exiting'
 
   echo ${_shunit_tmpDir_}
@@ -737,11 +737,11 @@ _shunit_mktempFunc() {
   for _shunit_func_ in oneTimeSetUp oneTimeTearDown setUp tearDown suite noexec
   do
     _shunit_file_="${__shunit_tmpDir}/${_shunit_func_}"
-    cat <<EOF >"${_shunit_file_}"
+    \cat <<EOF >"${_shunit_file_}"
 #! /bin/sh
 exit ${SHUNIT_TRUE}
 EOF
-    chmod +x "${_shunit_file_}"
+    \chmod +x "${_shunit_file_}"
   done
 
   unset _shunit_file_
@@ -770,16 +770,16 @@ _shunit_cleanup()
   esac
 
   # Do our work.
-  rm -fr "${__shunit_tmpDir}"
+  \rm -fr "${__shunit_tmpDir}"
 
   # Exit for all non-EXIT signals.
-  if [ ${_shunit_name_} != 'EXIT' ]; then
+  if \[ ${_shunit_name_} != 'EXIT' ]; then
     _shunit_warn "trapped and now handling the (${_shunit_name_}) signal"
     # Disable EXIT trap.
     trap 0
     # Add 128 to signal and exit.
     exit `expr ${_shunit_signal_} + 128`
-  elif [ ${__shunit_reportGenerated} -eq ${SHUNIT_FALSE} ] ; then
+  elif \[ ${__shunit_reportGenerated} -eq ${SHUNIT_FALSE} ] ; then
     _shunit_assertFail 'Unknown failure encountered running a test'
     _shunit_generateReport
     exit ${SHUNIT_ERROR}
@@ -847,7 +847,7 @@ _shunit_execSuite() {
     tearDown
 
     # update stats
-    if [ ${__shunit_testSuccess} -eq ${SHUNIT_TRUE} ]; then
+    if \[ ${__shunit_testSuccess} -eq ${SHUNIT_TRUE} ]; then
       __shunit_testsPassed=`expr ${__shunit_testsPassed} + 1`
     else
       __shunit_testsFailed=`expr ${__shunit_testsFailed} + 1`
@@ -867,31 +867,31 @@ _shunit_generateReport() {
   _shunit_ok_=${SHUNIT_TRUE}
 
   # If no exit code was provided one, determine an appropriate one.
-  [ ${__shunit_testsFailed} -gt 0 \
+  \[ ${__shunit_testsFailed} -gt 0 \
       -o ${__shunit_testSuccess} -eq ${SHUNIT_FALSE} ] \
           && _shunit_ok_=${SHUNIT_FALSE}
 
   echo
-  if [ ${__shunit_testsTotal} -eq 1 ]; then
-    ${__SHUNIT_CMD_ECHO_ESC} "Ran ${__shunit_ansi_cyan}${__shunit_testsTotal}${__shunit_ansi_none} test."
+  if \[ ${__shunit_testsTotal} -eq 1 ]; then
+    echo "Ran ${__shunit_testsTotal} test."
   else
     ${__SHUNIT_CMD_ECHO_ESC} "Ran ${__shunit_ansi_cyan}${__shunit_testsTotal}${__shunit_ansi_none} tests."
   fi
 
   _shunit_failures_=''
   _shunit_skipped_=''
-  [ ${__shunit_assertsFailed} -gt 0 ] \
+  \[ ${__shunit_assertsFailed} -gt 0 ] \
       && _shunit_failures_="failures=${__shunit_assertsFailed}"
-  [ ${__shunit_assertsSkipped} -gt 0 ] \
+  \[ ${__shunit_assertsSkipped} -gt 0 ] \
       && _shunit_skipped_="skipped=${__shunit_assertsSkipped}"
 
-  if [ ${_shunit_ok_} -eq ${SHUNIT_TRUE} ]; then
-    _shunit_msg_="${__shunit_ansi_green}OK"
-    [ -n "${_shunit_skipped_}" ] \
+  if \[ ${_shunit_ok_} -eq ${SHUNIT_TRUE} ]; then
+    _shunit_msg_='OK'
+    \[ -n "${_shunit_skipped_}" ] \
         && _shunit_msg_="${_shunit_msg_} (${_shunit_skipped_})"
   else
-    _shunit_msg_="${__shunit_ansi_red}FAILED (${_shunit_failures_}"
-    [ -n "${_shunit_skipped_}" ] \
+    _shunit_msg_="FAILED (${_shunit_failures_}"
+    \[ -n "${_shunit_skipped_}" ] \
         && _shunit_msg_="${_shunit_msg_},${_shunit_skipped_}"
     _shunit_msg_="${_shunit_msg_})"
   fi
@@ -909,8 +909,9 @@ _shunit_generateReport() {
 #   None
 # Returns:
 #   boolean: whether the test should be skipped (TRUE/FALSE constant)
-_shunit_shouldSkip() {
-  [ ${__shunit_skip} -eq ${SHUNIT_FALSE} ] && return ${SHUNIT_FALSE}
+_shunit_shouldSkip()
+{
+  \[ ${__shunit_skip} -eq ${SHUNIT_FALSE} ] && return ${SHUNIT_FALSE}
   _shunit_assertSkip
 }
 
@@ -972,8 +973,9 @@ _shunit_prepForSourcing()
 #   s: string: to escape character in
 # Returns:
 #   string: with escaped character(s)
-_shunit_escapeCharInStr() {
-  [ -n "$2" ] || return  # no point in doing work on an empty string
+_shunit_escapeCharInStr()
+{
+  \[ -n "$2" ] || return  # no point in doing work on an empty string
 
   # Note: using shorter variable names to prevent conflicts with
   # _shunit_escapeCharactersInString().
@@ -993,8 +995,9 @@ _shunit_escapeCharInStr() {
 #   str: string: to escape characters in
 # Returns:
 #   string: with escaped character(s)
-_shunit_escapeCharactersInString() {
-  [ -n "$1" ] || return  # no point in doing work on an empty string
+_shunit_escapeCharactersInString()
+{
+  \[ -n "$1" ] || return  # no point in doing work on an empty string
 
   _shunit_str_=$1
 
@@ -1032,12 +1035,12 @@ _shunit_extractTestFunctions() {
 #
 
 # Determine the operating mode.
-if [ $# -eq 0 ]; then
+if \[ $# -eq 0 ]; then
   __shunit_script=${__SHUNIT_PARENT}
   __shunit_mode=${__SHUNIT_MODE_SOURCED}
 else
   __shunit_script=$1
-  [ -r "${__shunit_script}" ] || \
+  \[ -r "${__shunit_script}" ] || \
       _shunit_fatal "unable to read from ${__shunit_script}"
   __shunit_mode=${__SHUNIT_MODE_STANDALONE}
 fi
@@ -1048,7 +1051,7 @@ __shunit_tmpDir=`_shunit_mktempDir`
 # Provide a public temporary directory for unit test scripts.
 # TODO(kward): document this.
 SHUNIT_TMPDIR="${__shunit_tmpDir}/tmp"
-mkdir "${SHUNIT_TMPDIR}"
+\mkdir "${SHUNIT_TMPDIR}"
 
 # Setup traps to clean up after ourselves.
 trap '_shunit_cleanup EXIT' 0
@@ -1066,7 +1069,7 @@ noexec 2>/dev/null || _shunit_fatal \
     'Please declare TMPDIR with path on partition with exec permission.'
 
 # We must manually source the tests in standalone mode.
-if [ "${__shunit_mode}" = "${__SHUNIT_MODE_STANDALONE}" ]; then
+if \[ "${__shunit_mode}" = "${__SHUNIT_MODE_STANDALONE}" ]; then
   . "`_shunit_prepForSourcing \"${__shunit_script}\"`"
 fi
 
@@ -1081,7 +1084,7 @@ oneTimeSetUp
 suite
 
 # If no suite function was defined, dynamically build a list of functions.
-if [ -z "${__shunit_suite}" ]; then
+if \[ -z "${__shunit_suite}" ]; then
   shunit_funcs_=`_shunit_extractTestFunctions "${__shunit_script}"`
   for shunit_func_ in ${shunit_funcs_}; do
     suite_addTest ${shunit_func_}
@@ -1094,5 +1097,5 @@ oneTimeTearDown
 _shunit_generateReport
 
 # That's it folks.
-[ ${__shunit_testsFailed} -eq 0 ]
+\[ ${__shunit_testsFailed} -eq 0 ]
 exit $?

--- a/shunit2_test_helpers
+++ b/shunit2_test_helpers
@@ -12,7 +12,7 @@
 set -u
 
 # Set shwordsplit for zsh.
-[ -n "${ZSH_VERSION:-}" ] && setopt shwordsplit
+\[ -n "${ZSH_VERSION:-}" ] && setopt shwordsplit
 
 #
 # Constants.
@@ -25,11 +25,11 @@ TH_SHUNIT=${SHUNIT_INC:-./shunit2}
 # non-empty value to enable debug output, or TRACE to enable trace
 # output.
 TRACE=${TRACE:+'th_trace '}
-[ -n "${TRACE}" ] && DEBUG=1
-[ -z "${TRACE}" ] && TRACE=':'
+\[ -n "${TRACE}" ] && DEBUG=1
+\[ -z "${TRACE}" ] && TRACE=':'
 
 DEBUG=${DEBUG:+'th_debug '}
-[ -z "${DEBUG}" ] && DEBUG=':'
+\[ -z "${DEBUG}" ] && DEBUG=':'
 
 #
 # Variables.
@@ -64,18 +64,18 @@ th_oneTimeSetUp() {
 th_generateRandom() {
   tfgr_random=${th_RANDOM}
 
-  while [ "${tfgr_random}" = "${th_RANDOM}" ]; do
-    if [ -n "${RANDOM:-}" ]; then
+  while \[ "${tfgr_random}" = "${th_RANDOM}" ]; do
+    if \[ -n "${RANDOM:-}" ]; then
       # $RANDOM works
       tfgr_random=${RANDOM}${RANDOM}${RANDOM}$$
-    elif [ -r '/dev/urandom' ]; then
+    elif \[ -r '/dev/urandom' ]; then
       tfgr_random=`od -vAn -N4 -tu4 </dev/urandom |sed 's/^[^0-9]*//'`
     else
       tfgr_date=`date '+%H%M%S'`
       tfgr_random=`expr ${tfgr_date} \* $$`
       unset tfgr_date
     fi
-    [ "${tfgr_random}" = "${th_RANDOM}" ] && sleep 1
+    \[ "${tfgr_random}" = "${th_RANDOM}" ] && sleep 1
   done
 
   th_RANDOM=${tfgr_random}
@@ -116,7 +116,7 @@ th_assertTrueWithNoOutput() {
   th_stderr_=$4
 
   assertTrue "${th_test_}; expected return value of zero" ${th_rtrn_}
-  [ ${th_rtrn_} -ne ${SHUNIT_TRUE} ] && cat "${th_stderr_}"
+  \[ ${th_rtrn_} -ne ${SHUNIT_TRUE} ] && \cat "${th_stderr_}"
   assertFalse "${th_test_}; expected no output to STDOUT" \
       "[ -s '${th_stdout_}' ]"
   assertFalse "${th_test_}; expected no output to STDERR" \
@@ -145,7 +145,7 @@ th_assertFalseWithOutput()
       "[ -s '${th_stdout_}' ]"
   assertFalse "${th_test_}; expected no output to STDERR" \
       "[ -s '${th_stderr_}' ]"
-  [ -s "${th_stdout_}" -a ! -s "${th_stderr_}" ] || \
+  \[ -s "${th_stdout_}" -a ! -s "${th_stderr_}" ] || \
       _th_showOutput ${SHUNIT_FALSE} "${th_stdout_}" "${th_stderr_}"
 
   unset th_test_ th_rtrn_ th_stdout_ th_stderr_
@@ -170,7 +170,7 @@ th_assertFalseWithError() {
       "[ -s '${th_stdout_}' ]"
   assertTrue "${th_test_}; expected output to STDERR" \
       "[ -s '${th_stderr_}' ]"
-  [ ! -s "${th_stdout_}" -a -s "${th_stderr_}" ] || \
+  \[ ! -s "${th_stdout_}" -a -s "${th_stderr_}" ] || \
       _th_showOutput ${SHUNIT_FALSE} "${th_stdout_}" "${th_stderr_}"
 
   unset th_test_ th_rtrn_ th_stdout_ th_stderr_
@@ -181,8 +181,8 @@ th_assertFalseWithError() {
 # they are either written to disk, or recognized as an error the file is empty.
 th_clearReturn() { cp /dev/null "${returnF}"; }
 th_queryReturn() {
-  if [ -s "${returnF}" ]; then
-    th_return=`cat "${returnF}"`
+  if \[ -s "${returnF}" ]; then
+    th_return=`\cat "${returnF}"`
   else
     th_return=${SHUNIT_ERROR}
   fi
@@ -196,16 +196,16 @@ _th_showOutput() {
   _th_stderr_=$3
 
   isSkipping
-  if [ $? -eq ${SHUNIT_FALSE} -a ${_th_return_} != ${SHUNIT_TRUE} ]; then
-    if [ -n "${_th_stdout_}" -a -s "${_th_stdout_}" ]; then
+  if \[ $? -eq ${SHUNIT_FALSE} -a ${_th_return_} != ${SHUNIT_TRUE} ]; then
+    if \[ -n "${_th_stdout_}" -a -s "${_th_stdout_}" ]; then
       echo '>>> STDOUT' >&2
-      cat "${_th_stdout_}" >&2
+      \cat "${_th_stdout_}" >&2
     fi
-    if [ -n "${_th_stderr_}" -a -s "${_th_stderr_}" ]; then
+    if \[ -n "${_th_stderr_}" -a -s "${_th_stderr_}" ]; then
       echo '>>> STDERR' >&2
-      cat "${_th_stderr_}" >&2
+      \cat "${_th_stderr_}" >&2
     fi
-    if [ -n "${_th_stdout_}" -o -n "${_th_stderr_}" ]; then
+    if \[ -n "${_th_stdout_}" -o -n "${_th_stderr_}" ]; then
       echo '<<< end output' >&2
     fi
   fi


### PR DESCRIPTION
Before this, attempts to create stubs of system commands like mkdir,
chmod etc and some built-ins like [ ... ], would break shunit2 itself.

This patch allows us to avoid this undesirable behaviour by prefixing
certain commands with the \ (backslash).

The commands changed are:

- [ ... ]
- mkdir
- chmod
- rm
- cat