### PR TITLE
Fixed extra space after lineno when without message

### DIFF
--- a/shunit2
+++ b/shunit2
@@ -545,6 +545,7 @@ failNotEquals() {
   shunit_expected_=$1
   shunit_actual_=$2
 
+  shunit_message_=${shunit_message_%% }
   _shunit_assertFail "${shunit_message_:+${shunit_message_} }expected:<${shunit_expected_}> but was:<${shunit_actual_}>"
 
   unset shunit_message_ shunit_expected_ shunit_actual_
@@ -577,6 +578,7 @@ failSame()
     shift
   fi
 
+  shunit_message_=${shunit_message_%% }
   _shunit_assertFail "${shunit_message_:+${shunit_message_} }expected not same"
 
   unset shunit_message_


### PR DESCRIPTION
The two consecutive spaces -- after line numbers without message argument -- in the following output is the reason of this PR:

```test_extraspace
ASSERT:expected:<foo> but was:<bar>
ASSERT:[5]  expected:<foo> but was:<bar>
ASSERT:foobar expected:<foo> but was:<bar>
ASSERT:[7] foobar expected:<foo> but was:<bar>
ASSERT:expected not same
ASSERT:[10]  expected not same
ASSERT:foobar expected not same
ASSERT:[12] foobar expected not same

Ran 1 test.

FAILED (failures=8)
```

using

```bash
#!/usr/bin/env bash

test_extraspace() {
   assertEquals foo bar
   ${_ASSERT_EQUALS_} foo bar
   assertEquals foobar foo bar
   ${_ASSERT_EQUALS_} foobar foo bar

   assertNotEquals foo foo
   ${_ASSERT_NOT_EQUALS_} foo foo
   assertNotEquals foobar foo foo
   ${_ASSERT_NOT_EQUALS_} foobar foo foo
}


source shunit2
```

It's a nitpick, but I just don't like them.