### PR TITLE
Fix tput warning

### DIFF
--- a/shunit2
+++ b/shunit2
@@ -841,7 +841,7 @@ _shunit_configureColor() {
     'auto')
       ( exec tput >/dev/null 2>&1 )  # Check for existence of tput command.
       if command [ $? -lt 127 ]; then
-        _shunit_tput_=`tput colors`
+        _shunit_tput_=`tput -T "${TERM}" colors`
         # shellcheck disable=SC2166,SC2181
         command [ $? -eq 0 -a "${_shunit_tput_}" -ge 16 ] && _shunit_color_=${SHUNIT_TRUE}
       fi


### PR DESCRIPTION
    " [: : integer expression expected"

If shunit was launched within sublime_text build tools
it will prompt above warning because of lacking of $TERM
environment variable.