### PR TITLE
Resolve #38 (Bash/Ksh-style functions)

### DIFF
--- a/shunit2
+++ b/shunit2
@@ -1079,10 +1079,10 @@ _shunit_extractTestFunctions() {
 
   # Extract the lines with test function names, strip of anything besides the
   # function name, and output everything on a single line.
-  _shunit_regex_='^[ 	]*(function )*test[A-Za-z0-9_]* *\(\)'
+  _shunit_regex_='^\s*((function test[A-Za-z0-9_-]*)|(test[A-Za-z0-9_-]* *\(\)))'
   # shellcheck disable=SC2196
   egrep "${_shunit_regex_}" "${_shunit_script_}" \
-  |sed 's/^[^A-Za-z0-9_]*//;s/^function //;s/\([A-Za-z0-9_]*\).*/\1/g' \
+  |sed 's/^[^A-Za-z0-9_-]*//;s/^function //;s/\([A-Za-z0-9_-]*\).*/\1/g' \
   |xargs
 
   unset _shunit_regex_ _shunit_script_

--- a/shunit2_misc_test.sh
+++ b/shunit2_misc_test.sh
@@ -223,10 +223,29 @@ testExtractTestFunctions() {
 #func_with_test_vars() {
 #  testVariable=1234
 #}
+## Function with keyword but no parenthesis
+#function test6 { echo '6'; }
+## Function with keyword but no parenthesis, multi-line
+#function test7 {
+#  echo '7';
+#}
+## Function with no parenthesis, '{' on next line
+#function test8
+#{
+#  echo '8'
+#}
+## Function with hyphenated name
+#test-9() {
+#  echo '9';
+#}
+## Function without parenthesis or keyword
+#test_foobar { echo 'hello world'; }
+## Function with multiple function keywords
+#function function test_test_test() { echo 'lorem'; }
 EOF
 
   actual=`_shunit_extractTestFunctions "${f}"`
-  assertEquals 'testABC test_def testG3 test4 test5' "${actual}"
+  assertEquals 'testABC test_def testG3 test4 test5 test6 test7 test8 test-9' "${actual}"
 }
 
 # Test that certain external commands sometimes "stubbed" by users


### PR DESCRIPTION
This adds support for newer bash/ksh style functions (i.e, functions using the `function` keyword but without `()` following the function name, and functions with hyphenated names). I also fixed a minor undocumented bug where `function function test() {}` would be treated as a valid function. Cheers!