### PR TITLE
Fixed report output to properly display skipped test count

### DIFF
--- a/shunit2
+++ b/shunit2
@@ -933,22 +933,15 @@ _shunit_generateReport() {
     ${__SHUNIT_CMD_ECHO_ESC} "${_shunit_msg_} tests."
   fi
 
-  _shunit_failures_=0
-  _shunit_skipped_=0
-  command [ "${__shunit_assertsFailed}" -gt 0 ] \
-      && _shunit_failures_="failures=${__shunit_assertsFailed}"
-  command [ "${__shunit_assertsSkipped}" -gt 0 ] \
-      && _shunit_skipped_="skipped=${__shunit_assertsSkipped}"
-
   if command [ ${_shunit_ok_} -eq ${SHUNIT_TRUE} ]; then
     _shunit_msg_="${__shunit_ansi_green}OK${__shunit_ansi_none}"
-    command [ "${_shunit_skipped_}" -gt 0 ] \
-        && _shunit_msg_="${_shunit_msg_} (${__shunit_ansi_yellow}${_shunit_skipped_}${__shunit_ansi_none})"
+    command [ "${__shunit_assertsSkipped}" -gt 0 ] \
+        && _shunit_msg_="${_shunit_msg_} (${__shunit_ansi_yellow}skipped=${__shunit_assertsSkipped}${__shunit_ansi_none})"
   else
     _shunit_msg_="${__shunit_ansi_red}FAILED${__shunit_ansi_none}"
-    _shunit_msg_="${_shunit_msg_} (${__shunit_ansi_red}${_shunit_failures_}${__shunit_ansi_none}"
-    command [ "${_shunit_skipped_}" -gt 0 ] \
-        && _shunit_msg_="${_shunit_msg_},${__shunit_ansi_yellow}${_shunit_skipped_}${__shunit_ansi_none}"
+    _shunit_msg_="${_shunit_msg_} (${__shunit_ansi_red}failures=${__shunit_assertsFailed}${__shunit_ansi_none}"
+    command [ "${__shunit_assertsSkipped}" -gt 0 ] \
+        && _shunit_msg_="${_shunit_msg_},${__shunit_ansi_yellow}skipped=${__shunit_assertsSkipped}${__shunit_ansi_none}"
     _shunit_msg_="${_shunit_msg_})"
   fi
 
@@ -956,7 +949,7 @@ _shunit_generateReport() {
   ${__SHUNIT_CMD_ECHO_ESC} "${_shunit_msg_}"
   __shunit_reportGenerated=${SHUNIT_TRUE}
 
-  unset _shunit_failures_ _shunit_msg_ _shunit_ok_ _shunit_skipped_
+  unset _shunit_msg_ _shunit_ok_
 }
 
 # Test for whether a function should be skipped.


### PR DESCRIPTION
The logic in _shunit_generateReport() was converting the skipped and failed counts from an integer to a string and then trying to do an int compare on the value when displaying.  This is causing an error when there's skipped tests in particular:

`Ran 16 tests.

./shunit2/shunit2: line 950: [: skipped=5: integer expression expected

FAILED (failures=1)
`

I've updated the logic in this method so that it only does if checks agains the actual integer counts and then displays the appropriate output.