### PR TITLE
Add assertContains function - #59

### DIFF
--- a/doc/shunit2.html
+++ b/doc/shunit2.html
@@ -507,6 +507,10 @@ quoted.</dd>
 <dd>This function is functionally equivalent to <tt class="docutils literal">assertEquals</tt>.</dd>
 <dt><tt class="docutils literal">assertNotSame [message] unexpected actual</tt></dt>
 <dd>This function is functionally equivalent to <tt class="docutils literal">assertNotEquals</tt>.</dd>
+<dt><tt class="docutils literal">assertContains [message] expected actual</tt></dt>
+<dd>Asserts that <em>expected</em> is a substring of <em>actual</em>. The <em>expected</em>
+and <em>actual</em> values can be either strings or integer values as both will be
+treated as strings. The <em>message</em> is optional, and must be quoted.</dd>
 <dt><tt class="docutils literal">assertNull [message] value</tt></dt>
 <dd>Asserts that <em>value</em> is <em>null</em>, or in shell terms, a zero-length string. The
 <em>value</em> must be a string as an integer value does not translate into a

--- a/doc/shunit2.txt
+++ b/doc/shunit2.txt
@@ -188,6 +188,11 @@ Asserts
 ``assertNotSame [message] unexpected actual``
   This function is functionally equivalent to ``assertNotEquals``.
 
+``assertContains [message] expected actual``
+  Asserts that *expected* is a substring of *actual*. The *expected* and
+  *actual* values can be either strings or integer values as  both will be
+  treated as strings. The *message* is optional, and must be quoted.
+
 ``assertNull [message] value``
   Asserts that *value* is *null*, or in shell terms, a zero-length string. The
   *value* must be a string as an integer value does not translate into a

--- a/shunit2
+++ b/shunit2
@@ -226,6 +226,49 @@ assertNotEquals() {
 # shellcheck disable=SC2016,SC2034
 _ASSERT_NOT_EQUALS_='eval assertNotEquals --lineno "${LINENO:-}"'
 
+# Assert that one string contains another
+#
+# Args:
+#   message: string: failure message [optional]
+#   expected: string: expected substring
+#   actual: string: actual value
+# Returns:
+#   integer: success (TRUE/FALSE/ERROR constant)
+assertContains() {
+  # shellcheck disable=SC2090
+  ${_SHUNIT_LINENO_}
+  if command [ $# -lt 2 -o $# -gt 3 ]; then
+    _shunit_error "assertContains() requires two or three arguments; $# given"
+    _shunit_assertFail
+    return ${SHUNIT_ERROR}
+  fi
+  _shunit_shouldSkip && return ${SHUNIT_TRUE}
+
+  shunit_message_=${__shunit_lineno}
+  if command [ $# -eq 3 ]; then
+    shunit_message_="${shunit_message_}$1 "
+    shift
+  fi
+  shunit_expected_=$1
+  shunit_actual_=$2
+  shunit_actual_hex_="$(  printf "%s" "${shunit_actual_}"   | od -An -tx1)"
+  shunit_expected_hex_="$(printf "%s" "${shunit_expected_}" | od -An -tx1)"
+
+  shunit_return=${SHUNIT_TRUE}
+  if echo "${shunit_actual_hex_}" | grep -F -q "${shunit_expected_hex_}"; then
+    _shunit_assertPass
+  else
+    fail "${shunit_message_:+${shunit_message_} }expected:<${shunit_expected_}> inside:<${shunit_actual_}>"
+    shunit_return=${SHUNIT_FALSE}
+  fi
+
+  unset shunit_message_ shunit_expected_ shunit_actual_ \
+      shunit_actual_hex_ shunit_expected_hex_
+  return ${shunit_return}
+}
+# shellcheck disable=SC2016,SC2034
+_ASSERT_CONTAINS_='eval assertContains --lineno "${LINENO:-}"'
+
 # Assert that a value is null (i.e. an empty string)
 #
 # Args:

--- a/shunit2_asserts_test.sh
+++ b/shunit2_asserts_test.sh
@@ -82,6 +82,44 @@ testAssertNotSame() {
   commonNotEqualsSame 'assertNotSame'
 }
 
+testAssertContains() {
+  ( assertContains 'x' 'yxy' >"${stdoutF}" 2>"${stderrF}" )
+  th_assertTrueWithNoOutput 'contains' $? "${stdoutF}" "${stderrF}"
+
+  ( assertContains "${MSG}" 'x' 'yxy' >"${stdoutF}" 2>"${stderrF}" )
+  th_assertTrueWithNoOutput 'contains, with msg' $? "${stdoutF}" "${stderrF}"
+
+  ( assertContains 'x' 'y' >"${stdoutF}" 2>"${stderrF}" )
+  th_assertFalseWithOutput 'not contains' $? "${stdoutF}" "${stderrF}"
+
+  ( assertContains '' '' >"${stdoutF}" 2>"${stderrF}" )
+  th_assertTrueWithNoOutput 'null values' $? "${stdoutF}" "${stderrF}"
+
+  ( assertContains '' 'x' >"${stdoutF}" 2>"${stderrF}" )
+  th_assertTrueWithNoOutput 'null expected' $? "${stdoutF}" "${stderrF}"
+
+  ( assertContains '[x]' 'yxy' >"${stdoutF}" 2>"${stderrF}" )
+  th_assertFalseWithOutput 'brackets not evaluated' $? "${stdoutF}" "${stderrF}"
+
+  ( assertContains 'x*' 'yxy' >"${stdoutF}" 2>"${stderrF}" )
+  th_assertFalseWithOutput 'wildcard not evaluated' $? "${stdoutF}" "${stderrF}"
+
+  ( assertContains '[x].*' 'y[x].*y' >"${stdoutF}" 2>"${stderrF}" )
+  th_assertTrueWithNoOutput 'regex taken literally' $? "${stdoutF}" "${stderrF}"
+
+  ( assertContains "$(printf 'b\nc')" "$(printf 'a\nb\nc\nd')" >"${stdoutF}" 2>"${stderrF}" )
+  th_assertTrueWithNoOutput 'multi-line match' $? "${stdoutF}" "${stderrF}"
+
+  ( assertContains "$(printf 'c\nb')" "$(printf 'a\nb\nc\nd')" >"${stdoutF}" 2>"${stderrF}" )
+  th_assertFalseWithOutput 'multi-line mismatch' $? "${stdoutF}" "${stderrF}"
+
+  ( assertContains arg1 >"${stdoutF}" 2>"${stderrF}" )
+  th_assertFalseWithError 'too few arguments' $? "${stdoutF}" "${stderrF}"
+
+  ( assertContains arg1 arg2 arg3 arg4 >"${stdoutF}" 2>"${stderrF}" )
+  th_assertFalseWithError 'too many arguments' $? "${stdoutF}" "${stderrF}"
+}
+
 testAssertNull() {
   ( assertNull '' >"${stdoutF}" 2>"${stderrF}" )
   th_assertTrueWithNoOutput 'null' $? "${stdoutF}" "${stderrF}"


### PR DESCRIPTION
I tried to be careful about following existing styles and usage of external commands. I saw `/usr/bin/od` already used, but `sed` in other places relies on PATH, so I just went with `od` - hex conversion allows finding multi-line substrings

Compared to existing assertEquals: 
```diff
diff -U 3 <( grep -A 39 "two values are equal" shunit2 ) <( grep -A 42 "one string contains" shunit2 )
--- /dev/fd/63	2018-09-29 00:41:17.492249592 -0500
+++ /dev/fd/62	2018-09-29 00:41:17.492249592 -0500
@@ -1,16 +1,16 @@
-# Assert that two values are equal to one another.
+# Assert that one string contains another
 #
 # Args:
 #   message: string: failure message [optional]
-#   expected: string: expected value
+#   expected: string: expected substring
 #   actual: string: actual value
 # Returns:
 #   integer: success (TRUE/FALSE/ERROR constant)
-assertEquals() {
+assertContains() {
   # shellcheck disable=SC2090
   ${_SHUNIT_LINENO_}
   if command [ $# -lt 2 -o $# -gt 3 ]; then
-    _shunit_error "assertEquals() requires two or three arguments; $# given"
+    _shunit_error "assertContains() requires two or three arguments; $# given"
     _shunit_assertFail
     return ${SHUNIT_ERROR}
   fi
@@ -18,23 +18,26 @@
 
   shunit_message_=${__shunit_lineno}
   if command [ $# -eq 3 ]; then
-    shunit_message_="${shunit_message_}$1"
+    shunit_message_="${shunit_message_}$1 "
     shift
   fi
   shunit_expected_=$1
   shunit_actual_=$2
+  shunit_actual_hex_="$(  printf "%s" "${shunit_actual_}"   | od -An -tx1)"
+  shunit_expected_hex_="$(printf "%s" "${shunit_expected_}" | od -An -tx1)"
 
   shunit_return=${SHUNIT_TRUE}
-  if command [ "${shunit_expected_}" = "${shunit_actual_}" ]; then
+  if echo "${shunit_actual_hex_}" | grep -F -q "${shunit_expected_hex_}"; then
     _shunit_assertPass
   else
-    failNotEquals "${shunit_message_}" "${shunit_expected_}" "${shunit_actual_}"
+    fail "${shunit_message_:+${shunit_message_} }expected:<${shunit_expected_}> inside:<${shunit_actual_}>"
     shunit_return=${SHUNIT_FALSE}
   fi
 
-  unset shunit_message_ shunit_expected_ shunit_actual_
+  unset shunit_message_ shunit_expected_ shunit_actual_ \
+      shunit_actual_hex_ shunit_expected_hex_
   return ${shunit_return}
 }
 # shellcheck disable=SC2016,SC2034
-_ASSERT_EQUALS_='eval assertEquals --lineno "${LINENO:-}"'
+_ASSERT_CONTAINS_='eval assertContains --lineno "${LINENO:-}"'
```
*fixed diff - Travis didn't like fgrep and variables in printf format string.