### PR TITLE
Add [Not]Contains assertions & corresponding [Not]Found failures.

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,14 @@ This function is functionally equivalent to `assertEquals`.
 
 This function is functionally equivalent to `assertNotEquals`.
 
+`assertContains [message] container content`
+
+Asserts that _container_ contains _content_. The _container_ and _content_ values can be either strings or integer values as both will be treated as strings. The _message_ is optional, and must be quoted.
+
+`assertNotContains [message] container content`
+
+Asserts that _container_ does not contain _content_. The _container_ and _content_ values can be either strings or integer values as both will be treaded as strings. The _message_ is optional, and must be quoted.
+
 `assertNull [message] value`
 
 Asserts that _value_ is _null_, or in shell terms, a zero-length string. The _value_ must be a string as an integer value does not translate into a zero-length string. The _message_ is optional, and must be quoted.
@@ -202,6 +210,18 @@ _Note: no actual comparison of expected and actual is done._
 Fails the test immediately, reporting that the _expected_ and _actual_ values are not the same. The _message_ is optional, and must be quoted.
 
 _Note: no actual comparison of expected and actual is done._
+
+`failFound [message] content`
+
+Fails the test immediately, reporting that the _content_ was found. The _message_ is optional, and must be quoted.
+
+_Note: no actual search of content is done._
+
+`failNotFound [message] content`
+
+Fails the test immediately, reporting that the _content_ was not found. The _message_ is optional, and must be quoted.
+
+_Note: no actual search of content is done._
 
 ### <a name="setup-teardown"></a> Setup/Teardown
 

--- a/shunit2
+++ b/shunit2
@@ -226,6 +226,86 @@ assertNotEquals() {
 # shellcheck disable=SC2016,SC2034
 _ASSERT_NOT_EQUALS_='eval assertNotEquals --lineno "${LINENO:-}"'
 
+# Assert that a container contains a content.
+#
+# Args:
+#   message: string: failure message [optional]
+#   container: string: container to analyze
+#   content: string: content to find
+# Returns:
+#   integer: success (TRUE/FALSE/ERROR constant)
+assertContains() {
+  # shellcheck disable=SC2090
+  ${_SHUNIT_LINENO_}
+  if command [ $# -lt 2 -o $# -gt 3 ]; then
+    _shunit_error "assertContains() requires two or three arguments; $# given"
+    _shunit_assertFail
+    return ${SHUNIT_ERROR}
+  fi
+  _shunit_shouldSkip && return ${SHUNIT_TRUE}
+
+  shunit_message_=${__shunit_lineno}
+  if command [ $# -eq 3 ]; then
+    shunit_message_="${shunit_message_}$1"
+    shift
+  fi
+  shunit_container_=$1
+  shunit_content_=$2
+
+  shunit_return=${SHUNIT_TRUE}
+  if echo "$shunit_container_" | grep -F "$shunit_content_" > /dev/null; then
+    _shunit_assertPass
+  else
+    failNotFound "${shunit_message_}" "${shunit_content_}"
+    shunit_return=${SHUNIT_FALSE}
+  fi
+
+  unset shunit_message_ shunit_container_ shunit_content_
+  return ${shunit_return}
+}
+# shellcheck disable=SC2016,SC2034
+_ASSERT_CONTAINS_='eval assertContains --lineno "${LINENO:-}"'
+
+# Assert that a container does not contain a content.
+#
+# Args:
+#   message: string: failure message [optional]
+#   container: string: container to analyze
+#   content: string: content to look for
+# Returns:
+#   integer: success (TRUE/FALSE/ERROR constant)
+assertNotContains() {
+  # shellcheck disable=SC2090
+  ${_SHUNIT_LINENO_}
+  if command [ $# -lt 2 -o $# -gt 3 ]; then
+    _shunit_error "assertNotContains() requires two or three arguments; $# given"
+    _shunit_assertFail
+    return ${SHUNIT_ERROR}
+  fi
+  _shunit_shouldSkip && return ${SHUNIT_TRUE}
+
+  shunit_message_=${__shunit_lineno}
+  if command [ $# -eq 3 ]; then
+    shunit_message_="${shunit_message_}$1"
+    shift
+  fi
+  shunit_container_=$1
+  shunit_content_=$2
+
+  shunit_return=${SHUNIT_TRUE}
+  if echo "$shunit_container_" | grep -F "$shunit_content_" > /dev/null; then
+    failFound "${shunit_message_}" "$@"
+    shunit_return=${SHUNIT_FALSE}
+  else
+    _shunit_assertPass
+  fi
+
+  unset shunit_message_ shunit_container_ shunit_content_
+  return ${shunit_return}
+}
+# shellcheck disable=SC2016,SC2034
+_ASSERT_NOT_CONTAINS_='eval assertNotContains --lineno "${LINENO:-}"'
+
 # Assert that a value is null (i.e. an empty string)
 #
 # Args:
@@ -554,6 +634,70 @@ failNotEquals() {
 }
 # shellcheck disable=SC2016,SC2034
 _FAIL_NOT_EQUALS_='eval failNotEquals --lineno "${LINENO:-}"'
+
+# Records a test failure, stating a value was found.
+#
+# Args:
+#   message: string: failure message [optional]
+#   content: string: found value
+# Returns:
+#   integer: success (TRUE/FALSE/ERROR constant)
+failFound()
+{
+  # shellcheck disable=SC2090
+  ${_SHUNIT_LINENO_}
+  if command [ $# -lt 1 -o $# -gt 2 ]; then
+    _shunit_error "failFound() requires one or two arguments; $# given"
+    return ${SHUNIT_ERROR}
+  fi
+  _shunit_shouldSkip && return ${SHUNIT_TRUE}
+
+  shunit_message_=${__shunit_lineno}
+  if command [ $# -eq 2 ]; then
+    shunit_message_="${shunit_message_}$1"
+    shift
+  fi
+
+  shunit_message_=${shunit_message_%% }
+  _shunit_assertFail "${shunit_message_:+${shunit_message_} }Found"
+
+  unset shunit_message_
+  return ${SHUNIT_FALSE}
+}
+# shellcheck disable=SC2016,SC2034
+_FAIL_FOUND_='eval failFound --lineno "${LINENO:-}"'
+
+# Records a test failure, stating a content was not found.
+#
+# Args:
+#   message: string: failure message [optional]
+#   content: string: content not found
+# Returns:
+#   integer: success (TRUE/FALSE/ERROR constant)
+failNotFound() {
+  # shellcheck disable=SC2090
+  ${_SHUNIT_LINENO_}
+  if command [ $# -lt 1 -o $# -gt 2 ]; then
+    _shunit_error "failNotFound() requires one or two arguments; $# given"
+    return ${SHUNIT_ERROR}
+  fi
+  _shunit_shouldSkip && return ${SHUNIT_TRUE}
+
+  shunit_message_=${__shunit_lineno}
+  if command [ $# -eq 2 ]; then
+    shunit_message_="${shunit_message_}$1"
+    shift
+  fi
+  shunit_content_=$1
+
+  shunit_message_=${shunit_message_%% }
+  _shunit_assertFail "${shunit_message_:+${shunit_message_} }Not found:<${shunit_content_}>"
+
+  unset shunit_message_ shunit_content_
+  return ${SHUNIT_FALSE}
+}
+# shellcheck disable=SC2016,SC2034
+_FAIL_NOT_FOUND_='eval failNotFound --lineno "${LINENO:-}"'
 
 # Records a test failure, stating two values should have been the same.
 #

--- a/shunit2_asserts_test.sh
+++ b/shunit2_asserts_test.sh
@@ -82,6 +82,64 @@ testAssertNotSame() {
   commonNotEqualsSame 'assertNotSame'
 }
 
+testAssertContains() {
+  ( assertContains 'abcdef' 'abc' >"${stdoutF}" 2>"${stderrF}" )
+  th_assertTrueWithNoOutput 'found' $? "${stdoutF}" "${stderrF}"
+
+  ( assertContains 'abcdef' 'bcd' >"${stdoutF}" 2>"${stderrF}" )
+  th_assertTrueWithNoOutput 'found' $? "${stdoutF}" "${stderrF}"
+
+  ( assertContains 'abcdef' 'def' >"${stdoutF}" 2>"${stderrF}" )
+  th_assertTrueWithNoOutput 'found' $? "${stdoutF}" "${stderrF}"
+
+  ( assertContains "${MSG}" 'abcdef' 'abc' >"${stdoutF}" 2>"${stderrF}" )
+  th_assertTrueWithNoOutput 'found, with msg' $? "${stdoutF}" "${stderrF}"
+
+  ( assertContains 'abcdef' 'xyz' >"${stdoutF}" 2>"${stderrF}" )
+  th_assertFalseWithOutput 'not found' $? "${stdoutF}" "${stderrF}"
+
+  ( assertContains 'abcdef' 'zab' >"${stdoutF}" 2>"${stderrF}" )
+  th_assertFalseWithOutput 'not found' $? "${stdoutF}" "${stderrF}"
+
+  ( assertContains 'abcdef' 'efg' >"${stdoutF}" 2>"${stderrF}" )
+  th_assertFalseWithOutput 'not found' $? "${stdoutF}" "${stderrF}"
+
+  ( assertContains 'abcdef' 'acf' >"${stdoutF}" 2>"${stderrF}" )
+  th_assertFalseWithOutput 'not found' $? "${stdoutF}" "${stderrF}"
+
+  ( assertContains 'abcdef' >"${stdoutF}" 2>"${stderrF}" )
+  th_assertFalseWithError 'too few arguments' $? "${stdoutF}" "${stderrF}"
+
+  ( assertContains arg1 arg2 arg3 arg4 >"${stdoutF}" 2>"${stderrF}" )
+  th_assertFalseWithError 'too many arguments' $? "${stdoutF}" "${stderrF}"
+}
+
+testAssertNotContains() {
+  ( assertNotContains 'abcdef' 'xyz' >"${stdoutF}" 2>"${stderrF}" )
+  th_assertTrueWithNoOutput 'not found' $? "${stdoutF}" "${stderrF}"
+
+  ( assertNotContains 'abcdef' 'zab' >"${stdoutF}" 2>"${stderrF}" )
+  th_assertTrueWithNoOutput 'not found' $? "${stdoutF}" "${stderrF}"
+
+  ( assertNotContains 'abcdef' 'efg' >"${stdoutF}" 2>"${stderrF}" )
+  th_assertTrueWithNoOutput 'not found' $? "${stdoutF}" "${stderrF}"
+
+  ( assertNotContains 'abcdef' 'acf' >"${stdoutF}" 2>"${stderrF}" )
+  th_assertTrueWithNoOutput 'not found' $? "${stdoutF}" "${stderrF}"
+
+  ( assertNotContains "${MSG}" 'abcdef' 'xyz' >"${stdoutF}" 2>"${stderrF}" )
+  th_assertTrueWithNoOutput 'not found, with msg' $? "${stdoutF}" "${stderrF}"
+
+  ( assertNotContains 'abcdef' 'abc' >"${stdoutF}" 2>"${stderrF}" )
+  th_assertFalseWithOutput 'found' $? "${stdoutF}" "${stderrF}"
+
+  ( assertNotContains 'abcdef' >"${stdoutF}" 2>"${stderrF}" )
+  th_assertFalseWithError 'too few arguments' $? "${stdoutF}" "${stderrF}"
+
+  ( assertNotContains arg1 arg2 arg3 arg4 >"${stdoutF}" 2>"${stderrF}" )
+  th_assertFalseWithError 'too many arguments' $? "${stdoutF}" "${stderrF}"
+}
+
 testAssertNull() {
   ( assertNull '' >"${stdoutF}" 2>"${stderrF}" )
   th_assertTrueWithNoOutput 'null' $? "${stdoutF}" "${stderrF}"


### PR DESCRIPTION
Here I add the `assertContains` asked in #59.
It is quite different from #96:
* I go further in terms of renaming, with proper `container` and `content` names ;
* Parameters are container first, content second, while #96 is the reverse ;
* I don't use `od` because I am not familiar with it and multi-line was not part of my use cases. Maybe good to add ;
* I also add `assertNotContains` for the symetry ;
* I also add `failFound` and `failNotFound` ;