### PR TITLE
Add alternate 'never' option to SHUNIT_COLOR, per the docs

### DIFF
--- a/shunit2
+++ b/shunit2
@@ -987,6 +987,7 @@ _shunit_configureColor() {
     'auto')
       command [ "`_shunit_colors`" -ge 16 ] && _shunit_color_=${SHUNIT_TRUE}
       ;;
+    'never') ;;
     'none') ;;
     *) _shunit_fatal "unrecognized color option '$1'" ;;
   esac


### PR DESCRIPTION
Ran into this while referencing the docs, but in the implementation it only allows 'none'.

Maybe it's better to alter the docs to say 'none' rather than 'never', but that's up to you the maintainer.