### PR TITLE
Enable colouring if tput colors >= 8 colours

### DIFF
--- a/shunit2
+++ b/shunit2
@@ -985,7 +985,7 @@ _shunit_configureColor() {
   case $1 in
     'always') _shunit_color_=${SHUNIT_TRUE} ;;
     'auto')
-      command [ "`_shunit_colors`" -ge 16 ] && _shunit_color_=${SHUNIT_TRUE}
+      command [ "`_shunit_colors`" -ge 8 ] && _shunit_color_=${SHUNIT_TRUE}
       ;;
     'none') ;;
     *) _shunit_fatal "unrecognized color option '$1'" ;;


### PR DESCRIPTION
Before this, the $SHUNIT_COLOR variable was defaulting to off if tput
colors returned less than 16. On some terminals, however, tput colors
returns 8, and coloured output still looks fine. Therefore, it seems
appropriate that "auto" should result in colouring on these terminals.

This change changes the behaviour so that colouring is enabled if tput
colors returns >= 8.