### PR TITLE
automatically infer SHUNIT_PARENT under zsh

### DIFF
--- a/examples/mkdir_test.sh
+++ b/examples/mkdir_test.sh
@@ -71,5 +71,4 @@ tearDown() {
 }
 
 # Load and run shUnit2.
-[ -n "${ZSH_VERSION:-}" ] && SHUNIT_PARENT=$0
 . ../shunit2

--- a/examples/mock_file_test.sh
+++ b/examples/mock_file_test.sh
@@ -29,5 +29,4 @@ EOF
 }
 
 # Load and run shUnit2.
-[ -n "${ZSH_VERSION:-}" ] && SHUNIT_PARENT=$0
 . ../shunit2

--- a/shunit2
+++ b/shunit2
@@ -67,8 +67,7 @@ if command [ -n "${ZSH_VERSION:-}" ]; then
     _shunit_fatal 'zsh shwordsplit option is required for proper operation'
   fi
   if command [ -z "${SHUNIT_PARENT:-}" ]; then
-    _shunit_fatal "zsh does not pass \$0 through properly. please declare \
-\"SHUNIT_PARENT=\$0\" before calling shUnit2"
+    SHUNIT_PARENT="$(setopt POSIX_ARGZERO; echo "$0")"
   fi
 fi
 

--- a/shunit2_asserts_test.sh
+++ b/shunit2_asserts_test.sh
@@ -250,6 +250,4 @@ oneTimeSetUp() {
 }
 
 # Load and run shunit2.
-# shellcheck disable=SC2034
-[ -n "${ZSH_VERSION:-}" ] && SHUNIT_PARENT=$0
 . "${TH_SHUNIT}"

--- a/shunit2_failures_test.sh
+++ b/shunit2_failures_test.sh
@@ -77,6 +77,4 @@ oneTimeSetUp() {
 }
 
 # Load and run shUnit2.
-# shellcheck disable=SC2034
-[ -n "${ZSH_VERSION:-}" ] && SHUNIT_PARENT=$0
 . "${TH_SHUNIT}"

--- a/shunit2_macros_test.sh
+++ b/shunit2_macros_test.sh
@@ -260,6 +260,4 @@ oneTimeSetUp() {
 SHUNIT_COLOR='none'; export SHUNIT_COLOR
 
 # Load and run shUnit2.
-# shellcheck disable=SC2034
-[ -n "${ZSH_VERSION:-}" ] && SHUNIT_PARENT="$0"
 . "${TH_SHUNIT}"

--- a/shunit2_misc_test.sh
+++ b/shunit2_misc_test.sh
@@ -311,6 +311,4 @@ oneTimeSetUp() {
 }
 
 # Load and run shUnit2.
-# shellcheck disable=SC2034
-[ -n "${ZSH_VERSION:-}" ] && SHUNIT_PARENT=$0
 . "${TH_SHUNIT}"


### PR DESCRIPTION
This PR attempts to remove the need for zsh scripts to explicitly set `SHUNIT_PARENT` when sourcing `shunit2`.