### PR TITLE
Fix typo in error message for assertFalse

### DIFF
--- a/shunit2
+++ b/shunit2
@@ -529,7 +529,7 @@ assertFalse() {
   # shellcheck disable=SC2090
   ${_SHUNIT_LINENO_}
   if command [ $# -lt 1 -o $# -gt 2 ]; then
-    _shunit_error "assertFalse() quires one or two arguments; $# given"
+    _shunit_error "assertFalse() requires one or two arguments; $# given"
     _shunit_assertFail
     return ${SHUNIT_ERROR}
   fi


### PR DESCRIPTION
Hello :) I noticed the typo while using shUnit2 in my own project. It was such a small thing I thought I'd fix it quickly and make a PR myself.

I couldn't find any contributing guidelines so I hope I'm not bending any rules here!