### PR TITLE
Also protect sed command

### DIFF
--- a/shunit2
+++ b/shunit2
@@ -902,7 +902,7 @@ _shunit_mktempDir() {
   # shellcheck disable=SC2039
   if command [ -r '/dev/urandom' -a -x '/usr/bin/od' ]; then
     _shunit_random_=`/usr/bin/od -vAn -N4 -tx4 </dev/urandom \
-        |sed 's/^[^0-9a-f]*//'`
+        |command sed 's/^[^0-9a-f]*//'`
   elif command [ -n "${RANDOM:-}" ]; then
     # $RANDOM works
     _shunit_random_=${RANDOM}${RANDOM}${RANDOM}$$
@@ -1203,7 +1203,7 @@ _shunit_escapeCharInStr() {
 
   # Escape the character.
   # shellcheck disable=SC1003,SC2086
-  echo ''${_shunit_s_}'' |sed 's/\'${_shunit_c_}'/\\\'${_shunit_c_}'/g'
+  echo ''${_shunit_s_}'' |command sed 's/\'${_shunit_c_}'/\\\'${_shunit_c_}'/g'
 
   unset _shunit_c_ _shunit_s_
 }
@@ -1243,7 +1243,7 @@ _shunit_extractTestFunctions() {
   _shunit_regex_='^\s*((function test[A-Za-z0-9_-]*)|(test[A-Za-z0-9_-]* *\(\)))'
   # shellcheck disable=SC2196
   egrep "${_shunit_regex_}" "${_shunit_script_}" \
-  |sed 's/^[^A-Za-z0-9_-]*//;s/^function //;s/\([A-Za-z0-9_-]*\).*/\1/g' \
+  |command sed 's/^[^A-Za-z0-9_-]*//;s/^function //;s/\([A-Za-z0-9_-]*\).*/\1/g' \
   |xargs
 
   unset _shunit_regex_ _shunit_script_

--- a/shunit2_misc_test.sh
+++ b/shunit2_misc_test.sh
@@ -249,9 +249,8 @@ EOF
 }
 
 # Test that certain external commands sometimes "stubbed" by users are escaped.
-# See Issue #54.
-testProtectedCommands() {
-  for c in mkdir rm cat chmod; do
+testIssue54() {
+  for c in mkdir rm cat chmod sed; do
     grep "^[^#]*${c} " "${TH_SHUNIT}" | grep -qv "command ${c}"
     assertFalse "external call to ${c} not protected somewhere" $?
   done


### PR DESCRIPTION
The sed command should be protected via the 'command sed' pattern along
with others also protected back in Issue #54.

Also updates test in shunit2_misc_test.sh for this and renames it for
clarity.