### PR TITLE
Updating documentation with the right value

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,7 +421,7 @@ use to you.
 | Constant          | Value |
 | ----------------- | ----- |
 | SHUNIT\_CMD\_EXPR | Override which `expr` command is used. By default `expr` is used, except on BSD systems where `gexpr` is used. |
-| SHUNIT\_COLOR     | Enable colorized output. Options are 'auto', 'always', or 'never', with 'auto' being the default. |
+| SHUNIT\_COLOR     | Enable colorized output. Options are 'auto', 'always', or 'none', with 'auto' being the default. |
 | SHUNIT\_PARENT    | The filename of the shell script containing the tests. This is needed specifically for Zsh support. |
 | SHUNIT\_TEST\_PREFIX | Define this variable to add a prefix in front of each test name that is output in the test report. |
 


### PR DESCRIPTION
As I was integrating shunit in jenkins, I wanted to deactivate the colors, and I set the variable to 'never', as specified by the documentation, receiving the following message from the framework:

shunit2:FATAL unrecognized color option 'never'

I look into the code and I show that the actual value is 'none'