### PR TITLE
pdksh -> mksh and correct path for shunit2 in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ testEquality() {
 }
 
 # Load shUnit2.
-. ./shunit2
+. ../shunit2
 ```
 
 Running the unit test should give results similar to the following.
@@ -168,7 +168,7 @@ testPartyLikeItIs1999() {
 }
 
 # Load shUnit2.
-. ./shunit2
+. ../shunit2
 ```
 
 So, what did you get? I guess it told you that this isn't 1999. Bummer, eh?
@@ -183,6 +183,15 @@ ton more examples, take a look at the tests provided with [log4sh][log4sh] or
 [shFlags][shflags]. Both provide excellent examples of more advanced usage.
 shUnit2 was after all written to meet the unit testing need that
 [log4sh][log4sh] had.
+
+If you are using distribution packaged shUnit2 which is accessible from
+`/usr/bin/shunit2` such as Debian, you can load shUnit2 without specifying its
+path.  So the last 2 lines in the above can be replaced by:
+
+```sh
+# Load shUnit2.
+. shunit2
+```
 
 ---
 
@@ -460,7 +469,7 @@ testLineNo() {
 }
 
 # Load shUnit2.
-. ./shunit2
+. ../shunit2
 ```
 
 Notes:
@@ -540,7 +549,7 @@ oneTimeSetUp() {
 }
 
 # Load and run shUnit2.
-. ./shunit2
+. ../shunit2
 ```
 
 Running the above test under the __bash__ shell will result in the following

--- a/README.md
+++ b/README.md
@@ -62,9 +62,9 @@ Cygwin                              | user      | unknown
 
 * Bourne Shell (__sh__)
 * BASH - GNU Bourne Again SHell (__bash__)
-* DASH (__dash__)
-* Korn Shell (__ksh__)
-* pdksh - Public Domain Korn Shell (__pdksh__)
+* DASH - Debian Almquist Shell (__dash__)
+* Korn Shell - AT&T version of the Korn shell (__ksh__)
+* mksh - MirBSD Korn Shell (__mksh__)
 * zsh - Zsh (__zsh__) (since 2.1.2) _please see the Zsh shell errata for more information_
 
 See the appropriate Release Notes for this release
@@ -479,7 +479,7 @@ Notes:
 
 1. Line numbers are not supported in all shells. If a shell does not support
    them, no errors will be thrown. Supported shells include: __bash__ (>=3.0),
-   __ksh__, __pdksh__, and __zsh__.
+   __ksh__, __mksh__, and __zsh__.
 
 ### <a name="test-skipping"></a> Test Skipping
 

--- a/test_runner
+++ b/test_runner
@@ -25,7 +25,7 @@
 RUNNER_LOADED=0
 
 RUNNER_ARGV0=`basename "$0"`
-RUNNER_SHELLS='/bin/sh ash /bin/bash /bin/dash /bin/ksh /bin/pdksh /bin/zsh'
+RUNNER_SHELLS='/bin/sh ash /bin/bash /bin/dash /bin/ksh /bin/mksh /bin/zsh'
 RUNNER_TEST_SUFFIX='_test.sh'
 true; RUNNER_TRUE=$?
 false; RUNNER_FALSE=$?


### PR DESCRIPTION
It has been more than 4 years since mksh has taken over pdksh.  So let's update it.

Also, README.md has wrong path (only one period even if it is meant to be run from examples directory).

Let me add way to use shunit2 provided by the distribution.  If script is in PATH variable path, it will be found without exact path.