### PR TITLE
Fix SHELL variable not being properly set in tests

### DIFF
--- a/test_runner
+++ b/test_runner
@@ -159,7 +159,7 @@ EOF
       echo "--- Executing the '`_runner_testName "${t}"`' test suite. ---"
       # ${shell_bin} needs word splitting.
       #   shellcheck disable=SC2086
-      ( exec ${shell_bin} "./${t}" 2>&1; )
+      ( SHELL="${shell_bin}" exec ${shell_bin} "./${t}" 2>&1; )
       test "${runner_passing_}" -eq ${RUNNER_TRUE} -a $? -eq ${RUNNER_TRUE}
       runner_passing_=$?
     done


### PR DESCRIPTION
In commit 3e9578d141313150fd939211543a1d315d2b3b9a the shell used in
`shunit2_misc_test.sh` was changed from `${SHUNIT_SHELL:-sh}` to
`${SHELL:-sh}` because `SHUNIT_SHELL` was not set anywhere.

However `exec ${shell_bin}` does not reset the `SHELL` variable, it
inherits it from the running shell.
This means before that change all misc tests were running with `sh` and
after the change the running shell was used instead of the shell that is
supposed to be tested.

This can be fixed by manually setting the `SHELL` variable.

This will now fail the travis build because the most misc tests don't
actually pass on `zsh` and `sh` fails `testIssue84` (at least on my
machine).