### PR TITLE
Exit instead of returning when there are failures

### DIFF
--- a/shunit2
+++ b/shunit2
@@ -1373,5 +1373,5 @@ _shunit_generateReport
 
 # That's it folks.
 if ! ${__SHUNIT_BUILTIN} [ "${__shunit_testsFailed}" -eq 0 ]; then
-  return ${SHUNIT_FALSE}
+  exit ${SHUNIT_FALSE}
 fi


### PR DESCRIPTION
With return statement, running tests using `shunit2 <file>` will print out
a warning message "can only `return' from a function or sourced script". This
regression has been introduced after the 2.1.8 release.

Fixes: #158