### PR TITLE
replace deprecated egrep with grep -E

### DIFF
--- a/shunit2
+++ b/shunit2
@@ -1272,7 +1272,7 @@ _shunit_extractTestFunctions() {
   # function name, and output everything on a single line.
   _shunit_regex_='^\s*((function test[A-Za-z0-9_-]*)|(test[A-Za-z0-9_-]* *\(\)))'
   # shellcheck disable=SC2196
-  egrep "${_shunit_regex_}" "${_shunit_script_}" \
+  grep -E "${_shunit_regex_}" "${_shunit_script_}" \
   |command sed 's/^[^A-Za-z0-9_-]*//;s/^function //;s/\([A-Za-z0-9_-]*\).*/\1/g' \
   |xargs
 


### PR DESCRIPTION
as stated in: https://www.phoronix.com/news/GNU-Grep-3.8-Stop-egrep-fgrep
egrep is now legacy and should not be used, we also see --> $cmd: warning: $cmd is obsolescent; using @grep@ @option@
warning when being run. lets run grep -E instead for the same functionality

Fixes: #177